### PR TITLE
Nd Array Support and Dot Product Operation added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ main
 build
 a.out
 ds/
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 main
 build
 a.out
+ds/

--- a/addOperation.h
+++ b/addOperation.h
@@ -26,3 +26,4 @@ class AddOperation : public Operation<T> {
 };
 
 #endif
+

--- a/common.h
+++ b/common.h
@@ -4,3 +4,4 @@
 #include <memory>
 
 using namespace std; 
+

--- a/common.h
+++ b/common.h
@@ -1,0 +1,6 @@
+#include <iostream>
+#include <vector>
+#include <assert.h>
+#include <memory>
+
+using namespace std; 

--- a/cudaOps.cu
+++ b/cudaOps.cu
@@ -1,0 +1,223 @@
+#include<iostream>
+#include <chrono>
+#include <thrust/host_vector.h>
+#include <thrust/device_vector.h>
+#include<vector>
+
+auto cpuVectorAddition(std::vector<int> &A, std::vector<int> &B) {
+    auto start = std::chrono::high_resolution_clock::now();
+    for(int i = 0;i< A.size();i++) {
+        A[i] += B[i];
+    }
+    auto stop = std::chrono::high_resolution_clock::now(); 
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start); 
+    std::cout <<"Speed of CPU vector Addition: " << duration.count() <<" micro seconds"<<std::endl; 
+    return duration.count();
+}
+
+__global__ void add(int *a, int *b, int*c) {
+    c[blockIdx.x] = a[blockIdx.x] + b[blockIdx.x];
+}
+
+// GPU vector Addition using Pointers
+auto gpuVectorAddition(std::vector<int> &A, std::vector<int> &B) {
+    size_t n= A.size();
+
+    int* h_A = A.data();
+    int* h_B = B.data();
+
+    int *d_a, *d_b, *d_c;
+    cudaMalloc((void**)&d_a, sizeof(int)*n);
+    cudaMalloc((void**)&d_b, sizeof(int)*n);
+    cudaMalloc((void**)&d_c, sizeof(int)*n);
+
+    cudaMemcpy((void *)d_a, h_A, sizeof(int)*n, cudaMemcpyHostToDevice);
+    cudaMemcpy((void *)d_b, h_B, sizeof(int)*n, cudaMemcpyHostToDevice);
+
+    // Timing stuff, record how many seconds it takes for this operation
+    cudaEvent_t launch_begin, launch_end;
+    cudaEventCreate(&launch_begin);
+    cudaEventCreate(&launch_end);
+
+    // Warmup
+    add<<<n,1>>>(d_a, d_b, d_c);// num blocks, num_threads
+    float total_time = 0;
+    // Get average of 100 runs
+    for(int i = 0;i<100;i++) {
+        cudaEventRecord(launch_begin,0);
+        add<<<n,1>>>(d_a, d_b, d_c);
+        cudaEventRecord(launch_end,0);
+        cudaEventSynchronize(launch_end);
+
+        float time = 0;
+        cudaEventElapsedTime(&time, launch_begin, launch_end);
+        total_time += time;
+    }
+
+    total_time /= 100;
+    std::cout <<"Speed of GPU vector Addition: " << total_time <<" micro seconds"<<std::endl; 
+
+    // Copy memory back and free stuff
+    cudaMemcpy((void *)h_A, d_c, sizeof(int)*n, cudaMemcpyDeviceToHost);
+
+    A.assign(h_A, h_A + n);
+    for(auto i: A) {
+        if(i != 0) {
+            std::cout<<i<< " False"<<std::endl;
+            break;
+        }
+    }
+
+    cudaFree(d_a);
+    cudaFree(d_b);
+    cudaFree(d_c);
+
+    return total_time;
+}
+
+void vectorAdditionTest() {
+    size_t n = 100000;
+    // std::cout<<n<<std::endl;
+
+    std::vector<int> A(n,1);
+    std::vector<int> B(n,-1);
+    auto timeCpu = cpuVectorAddition(A,B);
+    auto timeGpu = gpuVectorAddition(A,B);
+
+    std::cout<<"Speedup over CPU is: "<< (float)timeCpu/timeGpu <<std::endl;
+}
+
+// Observation for CPU vs GPU compute in vector addition, the answer why is as follows:
+
+// 1. CUDA has a start-up overhead. For "small" problems like this one, the startup overhead will outweigh any gains from using the GPU. 
+
+
+__global__ void mm(int* a, int* b, int* c, int width) {
+
+    int x = blockIdx.x; // block id
+    int y = threadIdx.x; // thread id
+    int temp = 0;
+    for(int i = 0;i< width;i++) {
+        temp += a[x*width + i]*b[i*width+ y];
+    }
+
+    c[x*width + y] = temp;
+}
+
+
+
+// GPU vector Addition using Pointers
+auto gpuMatrixMultiplication(std::vector<int> &A, std::vector<int> &B, int size, bool print) {
+    
+    size_t n= A.size();
+
+    int* h_A = A.data();
+    int* h_B = B.data();
+
+    int *d_a, *d_b, *d_c;
+    int* h_C = (int *)malloc(sizeof(int)*n);
+    cudaMalloc((void**)&d_a, sizeof(int)*n);
+    cudaMalloc((void**)&d_b, sizeof(int)*n);
+    cudaMalloc((void**)&d_c, sizeof(int)*n);
+
+    cudaMemcpy((void *)d_a, h_A, sizeof(int)*n, cudaMemcpyHostToDevice);
+    cudaMemcpy((void *)d_b, h_B, sizeof(int)*n, cudaMemcpyHostToDevice);
+
+    // Timing stuff, record how many seconds it takes for this operation
+    cudaEvent_t launch_begin, launch_end;
+    cudaEventCreate(&launch_begin);
+    cudaEventCreate(&launch_end);
+
+    // Warmup
+    
+    mm<<<size,size>>>(d_a, d_b, d_c,size);// num blocks, num_threads
+    float total_time = 0;
+    int num_times = 10;
+    if(!print){
+        // Get average of 100 runs
+        for(int i = 0;i<num_times;i++) {
+            cudaEventRecord(launch_begin,0);
+            mm<<<size,size>>>(d_a, d_b, d_c, size);
+            cudaEventRecord(launch_end,0);
+            cudaEventSynchronize(launch_end);
+            float time = 0;
+            cudaEventElapsedTime(&time, launch_begin, launch_end);
+            total_time += time;
+        }
+        
+    }
+
+    total_time /= num_times;
+
+    // Copy memory back and free stuff
+    cudaMemcpy(h_C, (void **)d_c, sizeof(int)*n, cudaMemcpyDeviceToHost);
+
+    if(print) {
+        for(int i = 0;i < n;i++) {
+            std::cout<<h_C[i]<<" ";
+        }
+        std::cout<<std::endl;
+    } else {
+        std::cout <<"Speed of GPU vector Multiplication: " << total_time <<" micro seconds"<<std::endl; 
+    }
+
+    cudaFree(d_a);
+    cudaFree(d_b);
+    cudaFree(d_c);
+
+    return total_time;
+}
+
+float mmCpu(std::vector<int> &a, std::vector<int> &b, int n,bool print) {
+
+    std::vector<int> c(n*n,0);
+    auto start = std::chrono::high_resolution_clock::now();
+
+    for(int i = 0;i<n;i++) {
+        for(int j = 0;j< n;j++) {
+            for(int k = 0;k < n;k++) {
+                c[i*n + k] += a[i*n + j] * b[j*n + k];
+            }
+        }
+    }
+
+    auto stop = std::chrono::high_resolution_clock::now(); 
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start); 
+
+    if(print) {
+        for(auto i: c) {
+            std::cout<<i<<" ";
+        }
+        std::cout<<std::endl;
+    } else {
+        std::cout <<"Speed of CPU vector Multiplication: " << duration.count() <<" micro seconds"<<std::endl; 
+    }
+
+    return duration.count();
+}
+
+void matrixMultiplySpeedTest() {
+    int size = 1024;
+    std::vector<int> A(size*size);
+    std::vector<int> B(size*size);
+    auto gpuSpeed = gpuMatrixMultiplication(A,B,size,false);
+    auto cpuSpeed = mmCpu(A,B,size,false);
+
+    std::cout<<"Speed of GPu over CPU is: "<< cpuSpeed/gpuSpeed<<std::endl;
+}
+
+
+void matrixMultiplyCorrectness() {
+    int size = 4;
+    std::vector<int> A = {3,1,2,4,3,1,2,4,3,1,2,4,3,1,2,4};
+    std::vector<int> B = {3,1,2,4,3,1,2,4,3,1,2,4,3,1,2,4};
+    gpuMatrixMultiplication(A,B,size,true);
+    mmCpu(A,B,size,true);
+
+}
+int main() {
+
+    matrixMultiplySpeedTest();
+    matrixMultiplyCorrectness();
+    return 1; 
+}

--- a/cudaOps.cu
+++ b/cudaOps.cu
@@ -221,3 +221,4 @@ int main() {
     matrixMultiplyCorrectness();
     return 1; 
 }
+

--- a/divideOperation.h
+++ b/divideOperation.h
@@ -26,3 +26,4 @@ class DivideOperation : public Operation<T> {
 };
 
 #endif
+

--- a/divideOperation.h
+++ b/divideOperation.h
@@ -11,15 +11,18 @@ two tensors.
 template <typename T>
 class DivideOperation : public Operation<T> {
     public:
-        Tensor<T> *t1, *t2; // Input tensors
-        Tensor<T> *t3; // Output tensor
+    Tensor<T> *t1 = NULL, *t2 = NULL; // Input tensors
+    Tensor<T> *t3 = NULL; // Output tensor
     
-    DivideOperation(Tensor<T> *t1, Tensor<T> *t2) {
+    DivideOperation(Tensor<T> *t1, Tensor<T> *t2) : Operation<T>(t1,t2) {
         this->t1 = t1;
         this->t2 = t2;
     }
 
-    void backward(vector<T> grad);
+    void backward(Matrix<T> grad);
+
     Tensor<T> forward();
+
 };
+
 #endif

--- a/dotOperation.h
+++ b/dotOperation.h
@@ -20,3 +20,4 @@ class DotOperation : public Operation<T> {
 };
 
 #endif
+

--- a/dotOperation.h
+++ b/dotOperation.h
@@ -1,24 +1,18 @@
-/*
-This file defines the AddOperation class which represents the addition of
-two tensors.
-*/
-
 #include "operation.h"
 
-#ifndef __OP_ADD_INCLUDED__   
-#define __OP_ADD_INCLUDED__   
+#ifndef __OP_DOT_INCLUDED__  
+#define __OP_DOT_INCLUDED__  
 
 template <typename T>
-class AddOperation : public Operation<T> {
+class DotOperation : public Operation<T> {
     public:
     Tensor<T> *t1 = NULL, *t2 = NULL; // Input tensors
     Tensor<T> *t3 = NULL; // Output tensor
-
-    AddOperation(Tensor<T> *t1, Tensor<T> *t2) : Operation<T>(t1,t2){
+    
+    DotOperation(Tensor<T> *t1, Tensor<T> *t2) {
         this->t1 = t1;
         this->t2 = t2;
     }
-
     void backward(Matrix<T> grad);
 
     Tensor<T> forward();

--- a/exponentOperation.h
+++ b/exponentOperation.h
@@ -25,3 +25,4 @@ class ExponentOperation : public Operation<T> {
 };
 
 #endif
+

--- a/exponentOperation.h
+++ b/exponentOperation.h
@@ -11,14 +11,17 @@ exponentiation of a tensor.
 template <typename T>
 class ExponentOperation : public Operation<T> {
     public:
-        Tensor<T> *t1; // Input tensor
-        Tensor<T> *t3; // Output tensor
+    Tensor<T> *t1 = NULL; // Input tensor
+    Tensor<T> *t3 = NULL; // Output tensor
     
-    ExponentOperation(Tensor<T> *t1) {
+    ExponentOperation(Tensor<T> *t1) : Operation<T>(t1) {
         this->t1 = t1;
     }
 
-    void backward(vector<T> grad);
+    void backward(Matrix<T> grad);
+
     Tensor<T> forward();
+
 };
+
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -105,3 +105,4 @@ int main() {
     cout<<endl;
     newSigmoidTest();
 }
+

--- a/main.cpp
+++ b/main.cpp
@@ -1,76 +1,107 @@
-/*
-This file contains code that is used to debug the project by implementing tests.
-*/
-
-#include "tensor.h" 
-#include "operations_Impl.h"
+#include "tfclone.h"
 
 void oldSigmoidTest() {
-    Tensor<float> w0(vector<float>{2});
-    Tensor<float> x0(vector<float>{-1});
 
-    Tensor<float> w1(vector<float>{-3});
-    Tensor<float> x1(vector<float>{-2});
+    Tensor<float> w0({2},{1});
+    Tensor<float> x0({-1},{1});
 
-    Tensor<float> w3(vector<float>{-3});
+    Tensor<float> w1({-3},{1});
+    Tensor<float> x1({-2},{1});
+
+    Tensor<float> w3({-3},{1});
     
     Tensor<float> a = w0*x0;
     Tensor<float> b = w1*x1;
     Tensor<float> c = a + b;
     Tensor<float> d = w3+c;
-    Tensor<float> e = Tensor<float>(vector<float>{-1});
+    Tensor<float> e({-1}, {1});
     Tensor<float> f = d*e;
     Tensor<float> g = f.exp();
-    Tensor<float> h = Tensor<float>(vector<float>{1});
+    Tensor<float> h({1}, {1});
     Tensor<float> i = g + h;
-    Tensor<float> j = Tensor<float>(vector<float>{1});
+    Tensor<float> j({1}, {1});
     Tensor<float> k = j/i;
+    
+    vector<float> vsl = {1};
+    vector<int> sh = {1};
+    auto grad = Matrix<float>(vsl,sh);
+    k.backward(grad);
 
-    k.backward(vector<float>{1});
 
+    cout<<w0.grad<<endl;
+    cout<<x0.grad<<endl;
 
-    printTensor(w0.grad);
-    printTensor(x0.grad);
+    cout<<w1.grad<<endl;
+    cout<<x1.grad<<endl;
 
-    printTensor(w1.grad);
-    printTensor(x1.grad);
-
-    printTensor(w3.grad);
+    cout<<w3.grad<<endl;
 }
 
+// WRONG BACKPROP: SOME ERROR WITH POINTERS AND OPERATION OVERLOADING.
 void newSigmoidTest() {
-    Tensor<float> w0(vector<float>{2});
-    Tensor<float> x0(vector<float>{-1});
+    Tensor<float> w0({2},{1});
+    Tensor<float> x0({-1},{1});
 
-    Tensor<float> w1(vector<float>{-3});
-    Tensor<float> x1(vector<float>{-2});
+    Tensor<float> w1({-3},{1});
+    Tensor<float> x1({-2},{1});
 
-    Tensor<float> w3(vector<float>{-3});
-    
-    Tensor<float> e = Tensor<float>(vector<float>{-1});
-    Tensor<float> h = Tensor<float>(vector<float>{1});
-    Tensor<float> j = Tensor<float>(vector<float>{1});
+    Tensor<float> w3({-3},{1});
+    Tensor<float> e({-1}, {1});
+    Tensor<float> h({1}, {1});
+    Tensor<float> j({1}, {1});
 
     Tensor<float> a = e*(w0*x0 + w1*x1 + w3);
     Tensor<float> k = j/(a.exp() + h);
-    k.backward(vector<float>{1});
+
+    vector<float> vsl = {1};
+    vector<int> sh = {1};
+    auto grad = Matrix<float>(vsl,sh);
+    k.backward(grad);
 
 
-    printTensor(w0.grad);
-    printTensor(x0.grad);
+    cout<<w0.grad<<endl;
+    cout<<x0.grad<<endl;
 
-    printTensor(w1.grad);
-    printTensor(x1.grad);
+    cout<<w1.grad<<endl;
+    cout<<x1.grad<<endl;
 
-    printTensor(w3.grad);
+    cout<<w3.grad<<endl;
 }
 
+/*
+API guide:
+
+    1. Tensor(vector) - 1 D vector
+    2. Tensor(vector, row, col) - 2 D vector
+    Operations are add, dot, multiply, divide, exponent for tensors
+
+    Matrix size will always be batch size, channels, height width
+    Or batch size, embedding size, y
+
+    Rules during simple add, sub. divide, multiply use broadcasting
+    During matrix multiply, then 2D matrices can only be multiplied. 
+
+    Cases will be multilayer perceptron, batch size, input vector
+    layer weights would be input vector, output layer, hence add one to batch size dim
+    The matrix multiply the uses two interior dims as 2D matrices as input
+     Output will be 
+
+*/
 
 int main() {
-
+    vector<int> a({1,2,3,4,5,6});
+    vector<int> b({1,2,3,4,5,6,4,5,6});
+    vector<int> shape1({2,3});
+    vector<int> shape2({3,3});
+    Matrix<int> m1(a,shape1);
+    Matrix<int> m2(b,shape2);
+    
+  
+    cout<<m1<<endl;
+    cout<<m2<<endl;
+    auto m3 = m1.dot(m2);
+    cout<<m3<<endl;
     oldSigmoidTest();
-
     cout<<endl;
-
     newSigmoidTest();
 }

--- a/makefile
+++ b/makefile
@@ -10,3 +10,4 @@ test: test.cpp
 gpuTest: cudaOps.cu
 	nvcc -std=c++14 cudaOps.cu -o build/cuda.o
 	./build/cuda.o
+	

--- a/makefile
+++ b/makefile
@@ -2,5 +2,11 @@ all: main.cpp
 	g++ -std=c++11 main.cpp -o build/main.o
 	./build/main.o
 debug: main.cpp
-	g++ -g -std=c++11 main.cpp -o build/main.d
-	./build/main.d
+	g++ -g -std=c++11 main.cpp -o build/main.o
+	./build/main.o
+test: test.cpp
+	g++ -std=c++11 test.cpp -lgtest -lgtest_main -pthread -o build/test.o
+	./build/test.o
+gpuTest: cudaOps.cu
+	nvcc -std=c++14 cudaOps.cu -o build/cuda.o
+	./build/cuda.o

--- a/matrix.h
+++ b/matrix.h
@@ -1,0 +1,325 @@
+/*
+    This file defines the Matrix class. Matrix supports creation of n dimensional arrays
+    It supports various arithmetic and matrix operations.
+*/
+#include "common.h"
+#include "overloads.h"
+
+#ifndef __MATRIX_FLOAT_INCLUDED__   
+#define __MATRIX_FLOAT_INCLUDED__  
+
+template<typename T>
+struct Matrix{
+    private:
+    
+    /* 
+        This vector tracks for each dimension- the total number of elements 
+        left to encounter if I continue deeper into the remaining dimensions.
+    */
+    vector<int> elemsEncounteredPerDim;
+
+    // Verifies that the shape provided and val vector provided are compatible in size
+    bool verifyShape(const vector<T> &val, const vector<int> &shape) {
+        bool s = true;
+        int p = 1;
+        for(auto i: shape) {
+            p = p*i;
+        }
+        if(p != val.size()) {
+            s = false;
+        }
+
+        return s;
+    }
+    
+    /* 
+        This function is used to compute the elemsEncounteredPerDim variable. 
+        See it's description for more detail
+    */
+    vector<int> computeShapes(const vector<int> &shapes) {
+        vector<int> elems(shapes.size());
+        int p = 1;
+
+        for(int i = shapes.size()-1; i >=0;i--) {
+            elems[i] = p;
+            p *= shapes.at(i);
+        }
+
+        return elems;
+    }
+
+    /*
+        This function checks that the 2 matrices are compatible with each other to perform elementwise 
+        operations. Operations such as *, + and / are elementwise operations and they require the two 
+        matrices to have the same shape. 
+    */
+    bool verifyShapeForElementwiseOperation(const vector<int> &shape1, const vector<int> &shape2) {
+        
+        int n = shape1.size();
+        int m = shape2.size();
+
+        if(n != m) {
+            return false;
+        }
+
+        for(int i = 0;i<n;i++) {
+            if(shape1.at(i) != shape2.at(i)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /*
+        This function verifies that the 2 matrices are compatible for dot product multiplication.
+        Currently, this dot product functionality allows the lhs matrix (with shape1) to have 2 or 
+        more dimensions. The rhs matrix should have 2 dimensions. The multiplication will occur by 
+        traversing through the n-2 dimensions of matrix 1, until we get a 2d matrix of lhs. Then we
+        perform matrix multiplication with this 2 d lhs matrix and the rhs matrix. This function
+        performs a check to verify whether the two matrices are compatible for matrix multiplication.
+    */
+    bool verifyShapeForDotProductOperation(const vector<int> &shape1, const vector<int> &shape2) {
+        int n = shape1.size();
+        int m = shape2.size();
+
+        if(n < 2 || m != 2) {
+            return false;
+        } 
+
+        auto col1 = shape1.at(n-1);
+        auto row1 = shape1.at(n-2);
+        auto col2 = shape2.at(m-1);
+        auto row2 = shape2.at(m-2);
+
+        if(col1 != row2) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /*
+        This is a utility function for matrix multiplication that performs the actual dot product.
+        It gets as input the reference of the result vector, the 2d rhs matrix, the start index that 
+        tracks the position from which to start in the n dimensional lhs matrix and resStart tracks
+        the position to start in the result vector 
+    */
+    void matmulUtil(vector<T> &res,
+            const Matrix<T> &rhs,
+            int start, int startRes) {
+        int row1 = this->shape[this->shape.size()-2];
+        int col1 = this->shape[this->shape.size()-1];
+        int row2 = rhs.shape[rhs.shape.size()-2];
+        int col2 = rhs.shape[rhs.shape.size()-1];
+        // Sanity Check
+        assert(col1 == row2);
+
+        // O(n^3) complexity 
+        for(int i = 0;i<row1;i++) {
+            for(int k = 0;k < col2;k++) {
+                T sum = 0;
+                for(int j = 0;j< col1;j++) {
+                    sum += this->val[start+ i*col1 + j] * rhs.val[j*col2 + k];
+                }
+                res[(startRes+ i*col2 + k)] = sum;
+            }
+        }
+    }
+
+    /*
+        This function performs the matrix multiplication between a n dimensional matrix and a 2d matrix.
+        To view it's usage check the dot() function from where it is called. It is a recursive function
+        that calls itself until two 2d matrices have been got. It keeps a track of the position of nd 
+        matrix by using a stack. The stack keeps a track of the index of each dimension that has been
+        traversed. We use this information to find the index from where to start the 2d matrix 
+        multiplication. To find out the index from where to do the  2D matrix multiplication, we shall 
+        look into an example:
+
+        Assume we have 2 matrices of shape A = (3,4,2,1) and B = (1,2)
+        Assume we are currently at position [2][3] in our lhs matrix.
+        C = A[2][3];
+
+        Hence we are ready to do our 2d matrix multiplication as we have two 2d matrices C and B now.
+        But since our matrix is stored as a 1d vector , we need to find the index from where to start
+        the multiplicatoinn for A.
+        The right index would be 2*(num_col_for_dimension_0) + 3*(num_col_for_dimension_1).
+
+        These num cols for each dimension are stored in the elemsEncounteredPerDim vector.
+        Hence we use this information to find out the correct starting index of A.
+
+        We use a similiar thing to track the starting index of result vector by computing 
+        num_cols_per_dimension in resElems.
+
+        Lastly the dim parameter tracks what the current dimension is. IT start from 0 and keeps 
+        on being incremented after each function call.
+
+    */
+    void matmul(vector<T> &res,
+                    const Matrix<T> &rhs,
+                    vector<int> &stack,
+                    const vector<int> &resElems,
+                    int dim) {
+        // Case when both matrices are 2D
+        if(stack.size() == shape.size()-2) {
+            int p = 0;
+            int s = 0;
+            for(int i = 0;i < stack.size();i++) {
+                p += elemsEncounteredPerDim[i]*stack[i];
+                s += resElems[i]*stack[i];
+            }
+            // Do normal 2D matrix multiplication now
+            matmulUtil(res,rhs,p,s);
+            return;
+        }
+        // Case when larger matrix is bigger than rhs matrix
+        for(int i = 0;i < this->shape.at(dim);i++) {
+            stack.push_back(i); // Calculates how many elements have been processed, to get pointer to right location in val and pushes to stack
+            matmul(res,rhs,stack,resElems,dim+1);
+            stack.pop_back(); // Pops out of stack
+        }
+    }
+
+    public:
+    vector<T> val; // underlying data structure that holds the values of matrix
+    vector<int> shape; // shape of that matrix
+    
+    /* 
+        Need this default constructor without which program seems to error out
+        TODO: needs investigatio on why this happening
+    */
+    Matrix() {
+        //Default
+    }
+
+    // Constructor for matrix, validates shape before creating object
+    Matrix(vector<T> val, vector<int> shape) {
+        // Deep Copy
+        assert("Shape and size of vector are incompatible !" && verifyShape(val,shape));
+        this->val = val;
+        this->shape = shape;
+        this->elemsEncounteredPerDim = computeShapes(shape);
+    }
+
+    /* 
+        Print's out Matrix in human readable format, useful debugging small matrices.
+        This function is used by the overloaded << operator. Foloows a simialr structure to the matmul
+        function
+    */
+    ostream & print(ostream &out, vector<int> &stack, int dim) {
+        if(stack.size() == shape.size()-1) {
+            int p = 0;
+            for(auto i = 0;i < stack.size();i++) {
+                p += stack[i];
+            }
+            out<<"[ ";
+            for(auto i=0; i< this->shape.at(dim); i++) {
+                out<<this->val.at(p+i)<<" ";
+            }
+            out<<"]";
+            return out;
+        }
+
+        out<<"[ ";
+        for(auto i = 0;i < this->shape.at(dim);i++) {
+            stack.push_back(elemsEncounteredPerDim[dim]*i); // Calculates how many elements have been processed, to get pointer to right location in val and pushes to stack
+            print(out,stack,dim+1);
+            stack.pop_back(); // Pops out of stack
+        }
+        out<<" ]";
+        return out;
+    }
+
+    // Performs elementwise addition
+    Matrix<T> operator + (const Matrix<T> &rhs) {
+        assert("Shapes aren't compatible for addition !" &&
+         verifyShapeForElementwiseOperation(this->shape, rhs.shape));
+
+        auto res = this->val + rhs.val;
+        auto resShape = this->shape;
+        return Matrix(res, resShape);
+    }
+
+    // Performs elementwise multiplication
+    Matrix<T> operator * (const Matrix<T> &rhs) {
+        assert("Shapes aren't compatible for multiplication !" &&
+         verifyShapeForElementwiseOperation(this->shape, rhs.shape));
+
+        auto res = this->val * rhs.val;
+        auto resShape = this->shape;
+        return Matrix(res, resShape);
+    }
+
+    // Performs elementwise division
+    Matrix<T> operator / (const Matrix<T> &rhs) {
+        assert("Shapes aren't compatible for division !" && 
+        verifyShapeForElementwiseOperation(this->shape, rhs.shape));
+
+        auto res = this->val / rhs.val;
+        auto resShape = this->shape;
+        return Matrix(res, resShape);
+    }
+
+    // Performs power operation with scalar
+    Matrix<T> operator ^ (const T &rhs) {
+        auto res = this->val ^ rhs;
+        auto resShape = this->shape;
+        return Matrix(res, resShape);
+    }
+
+    // Perfroms exponent operation on each value of matrix
+    Matrix<T> exp() {
+        auto res = exponent(this->val);
+        auto resShape = this->shape;
+        return Matrix(res, resShape);
+    }
+
+    // Dot Product between 2 matrices. Check matmul for indepth description.
+    Matrix<T> dot(const Matrix<T> &rhs) {
+        assert("Shapes aren't compatible for dot product !" && 
+        verifyShapeForDotProductOperation(this->shape, rhs.shape));
+        
+        // Calc size of res array
+        auto size = 1; // total size of resultant matrix
+        vector<int> resShape;
+        for(auto i = 0;i < this->shape.size()-1;i++) {
+            size *= this->shape[i];
+            resShape.push_back(this->shape[i]);
+        }
+
+        size*=rhs.shape[rhs.shape.size()-1];
+        resShape.push_back(rhs.shape[rhs.shape.size()-1]);
+
+        vector<T> res(size,0);
+        vector<int> stack;
+
+        auto resElems = computeShapes(resShape);
+
+        matmul(res,rhs,stack,resElems,0);
+
+        return Matrix(res, resShape);
+    }
+
+
+    // Delete matrix
+    ~Matrix() {
+        
+    }
+};
+
+// Overloaded function for cout<<matrix<<endl;
+template<typename T>
+ostream & operator << (ostream &out, Matrix<T> &m) {
+    vector<int> stack;
+    return m.print(out,stack,0);
+}
+
+// Divison with a scalar as divident
+template<typename E>
+Matrix<E> operator / (const E e, const Matrix<E> &rhs) {
+    auto res =  e/rhs.val;
+    auto resShape = rhs.shape;
+    return Matrix<E>(res, resShape);
+}
+
+#endif

--- a/matrix.h
+++ b/matrix.h
@@ -323,3 +323,4 @@ Matrix<E> operator / (const E e, const Matrix<E> &rhs) {
 }
 
 #endif
+

--- a/multiplyOperation.h
+++ b/multiplyOperation.h
@@ -1,6 +1,6 @@
 /*
-This file defines the MultiplyOperation class which represents the
-multiplication of two tensors.
+    This file defines the MultiplyOperation class which represents the
+    multiplication of two tensors.
 */
 
 #include "operation.h"
@@ -11,15 +11,15 @@ multiplication of two tensors.
 template <typename T>
 class MultiplyOperation : public Operation<T> {
     public:
-        Tensor<T> *t1, *t2; // Input tensors
-        Tensor<T> *t3; // Output tensor
+    Tensor<T> *t1 = NULL, *t2 = NULL; // Input tensors
+    Tensor<T> *t3 = NULL; // Output tensor
     
-    MultiplyOperation(Tensor<T> *t1, Tensor<T> *t2) {
+    MultiplyOperation(Tensor<T> *t1, Tensor<T> *t2) : Operation<T>(t1,t2) {
         this->t1 = t1;
         this->t2 = t2;
     }
+    void backward(Matrix<T> grad);
 
-    void backward(vector<T> grad);
     Tensor<T> forward();
 };
 

--- a/multiplyOperation.h
+++ b/multiplyOperation.h
@@ -24,3 +24,4 @@ class MultiplyOperation : public Operation<T> {
 };
 
 #endif
+

--- a/operation.h
+++ b/operation.h
@@ -6,21 +6,32 @@ performed on one or more tensors.
 #ifndef __OP_H_INCLUDED__   
 #define __OP_H_INCLUDED__   
 
-#include <iostream>
-#include <vector>
+#include "common.h"
+#include "matrix.h"
 
-using namespace std; 
-
+//Forward Declaration
 template<typename T>
 class Tensor;
 
 template<typename T>
 class Operation {
     public:
-        Tensor<T> *t1, *t2; // generally an operation has two operands
+    Tensor<T> *t1 = NULL, *t2 = NULL; // generally an operation had two operands
+    
+    Operation() {
 
-        virtual void backward(vector<T> grad) = 0;
-        virtual Tensor<T> forward() = 0;
+    }
+    Operation(Tensor<T> *t1) {
+        this->t1 = t1;
+    }
+
+    Operation(Tensor<T> *t1, Tensor<T> *t2) {
+        this->t1 = t1;
+        this->t2 = t2;
+    }
+
+    virtual void backward(Matrix<T> grad) = 0;
+    virtual Tensor<T> forward() = 0;
 };
 
 #endif

--- a/operation.h
+++ b/operation.h
@@ -35,3 +35,4 @@ class Operation {
 };
 
 #endif
+

--- a/operations_Impl.h
+++ b/operations_Impl.h
@@ -6,13 +6,16 @@ the operations.
 #include "multiplyOperation.h"
 #include "addOperation.h"
 #include "divideOperation.h"
-#include "tensor.h"
-#include "overloads.h"
+#include "dotOperation.h"
+
+// We want to define forward and backprop relating to both vector to vector, vector to matrix and matrix to matrix operations.
+// multiplication is dot product multiplication
+// addition is element wise addition
+// division is elementwise multiplication
 
 template <typename T>
-void MultiplyOperation<T>::backward(vector<T> grad) {
-    // cout<<this->t2->val<<endl;
-    // Swithing case: weherre gradients are multiplied with the opposite tensor
+void MultiplyOperation<T>::backward(Matrix<T> grad) {
+    // Swithing case: where gradients are multiplied with the opposite tensor
     this->t1->backward(grad*this->t2->val);
     this->t2->backward(grad*this->t1->val);
 }
@@ -23,10 +26,23 @@ Tensor<T> MultiplyOperation<T>::forward() {
     return *this->t3;
 }
 
+// TODO
 template <typename T>
-void AddOperation<T>::backward(vector<T> grad) {
-    // cout<<this->t2->val<<endl;
-    // Distributing case: weherre gradients are backproped as is
+void DotOperation<T>::backward(Matrix<T> grad) {
+    // TODO 
+    
+}
+
+// TODO
+template <typename T>
+Tensor<T> DotOperation<T>::forward() {
+    // TODO
+    return *this->t1;
+}
+
+template <typename T>
+void AddOperation<T>::backward(Matrix<T> grad) {
+    // Distributing case: where gradients are backproped as is
     this->t1->backward(grad);
     this->t2->backward(grad);
 }
@@ -41,11 +57,10 @@ Tensor<T> AddOperation<T>::forward() {
 // for dF/dx = grad/y
 // dF/dy = (grad*x* (-1))/y^2
 template <typename T>
-void DivideOperation<T>::backward(vector<T> grad) {
-    // cout<<this->t2->val<<endl;
+void DivideOperation<T>::backward(Matrix<T> grad) {
     // Swithing case: weherre gradients are multiplied with the opposite tensor
     this->t1->backward(grad / this->t2->val);
-    vector<T> temp = grad * this->t1->val;
+    auto temp = grad * this->t1->val;
     this->t2->backward(temp*( (T)(-1) / (this->t2->val^(T)2)));
 }
 
@@ -57,12 +72,12 @@ Tensor<T> DivideOperation<T>::forward() {
 
 // Exponent Backprop
 template <typename T>
-void ExponentOperation<T>::backward(vector<T> grad) {
-    this->t1->backward(grad*exponent(this->t1->val));
+void ExponentOperation<T>::backward(Matrix<T> grad) {
+    this->t1->backward(grad*(this->t1->val.exp()));
 }
 
 template <typename T>
 Tensor<T> ExponentOperation<T>::forward() {
-    this->t3 = new Tensor<T>(exponent(this->t1->val), this);
+    this->t3 = new Tensor<T>(this->t1->val.exp(), this);
     return *this->t3;
 }

--- a/operations_Impl.h
+++ b/operations_Impl.h
@@ -81,3 +81,4 @@ Tensor<T> ExponentOperation<T>::forward() {
     this->t3 = new Tensor<T>(this->t1->val.exp(), this);
     return *this->t3;
 }
+

--- a/overloads.h
+++ b/overloads.h
@@ -75,3 +75,4 @@ vector<T> exponent(const vector<T> &a) {
 }
 
 #endif
+

--- a/overloads.h
+++ b/overloads.h
@@ -1,13 +1,8 @@
-/*
-This file defines the arithmetic operator overloads for Tensor class objects and
-implements the operations.
-*/
-#include "assert.h"
-
-#include <vector>
+#include "common.h"
 #include <cmath>
 
-using namespace std;
+#ifndef __VEC_OVERLOADS_FLOAT_INCLUDED__   
+#define __VEC_OVERLOADS_FLOAT_INCLUDED__  
 
 // Multiplication
 template<typename T>
@@ -69,7 +64,8 @@ vector<T> operator ^ (vector<T> &a, const T b) {
 
 // Expoenent Operation
 template<typename T>
-vector<T> exponent(vector<T> &a) {
+vector<T> exponent(const vector<T> &a) {
+
     vector<T> arr;
     for(int i = 0;i<a.size();i++) {
         T prod = exp(a[i]);
@@ -77,3 +73,5 @@ vector<T> exponent(vector<T> &a) {
     }
     return arr;
 }
+
+#endif

--- a/tensor.h
+++ b/tensor.h
@@ -9,36 +9,33 @@ being executed on it in the form of pointers to Operation objects.
 #include "multiplyOperation.h"
 #include "divideOperation.h"
 #include "exponentOperation.h"
+#include "dotOperation.h"
 
 #ifndef __TENSOR_FLOAT_INCLUDED__   
 #define __TENSOR_FLOAT_INCLUDED__   
 
-template<typename T>
-void printTensor(vector<T> &a) {
-    for(auto i: a) {
-        cout<<i<<" ";
-    }
-    cout<<endl;
-}
-
 template <typename T>
 class Tensor {
     public:
-    vector<T> val; // value of tensor 
-    vector<T> grad; // value of grad
+    Matrix<T> val; // value of tensor 
+    Matrix<T> grad; // value of grad
+
     Operation<T> *frontOp =NULL, *backOp =NULL;
 
     Tensor() {
         // default
+        cout<<"Normal Constructor is called"<<endl;
     }
 
-    // This is a copy constrructore needed for when we encounter temporaries.
-    // In a big expression, for example a*(b+c) has the (b+c) temporary
-    // which comes in the form of const Tensor, this const Tensor gives problems and
-    // weird values for grad and val when backpropping through it.
-    // We create a normal non const Tensor whenever we encounter this const Tensor, 
-    // hence this copy constructor is used. Check the const operator overloading for
-    // usage of this constructor.
+    /*
+        This is a copy constructor needed for when we encounter temporaries.
+        In a big expression, for example a*(b+c) has the (b+c) temporary
+        which comes in the form of const Tensor, this const Tensor gives problems and
+        weird values for grad and val when backpropping through it.
+        We create a normal non const Tensor whenever we encounter this const Tensor, 
+        hence this copy constructor is used. Check the const operator overloading for
+        usage of this constructor.
+    */
     Tensor(const Tensor<T> *two) {
         this->val = two->val;
         this->backOp = two->backOp;
@@ -46,68 +43,82 @@ class Tensor {
         this->grad = two->grad;
     }
 
-    Tensor(vector<T> val) {
+    Tensor(Matrix<T> &val) {
         this->val = val;
     }
 
-    Tensor(vector<T> val, Operation<T>* op) {
+    Tensor(vector<T> val, vector<int> shape) {
+        this->val = Matrix<T>(val,shape);
+    }
+
+    Tensor(Matrix<T> val, Operation<T>* op) {
         this->val = val;
         this->backOp = op;
     }
 
-    void backward(vector<T> grad) {
-        // printTensor(this->val);
+    void backward(Matrix<T> grad) {
+        // TODO: add assertions that the gradient is of the same shape of val
         this->grad = grad;
         if(this->backOp != NULL) {
             this->backOp->backward(grad);
         }
     }
 
-    // Overloading Operations , one for const and one for actual variable
+    // Overloading Operations, one for const and one for actual variable
     // hence each operation has two overloads, except exp()
     Tensor<T> operator * (Tensor<T> &two) { 
+        // TODO: add assertions
         this->frontOp = new MultiplyOperation<T>(this, &two);
         two.frontOp = this->frontOp;
         return this->frontOp->forward();
     }
 
     Tensor<T> operator * (const Tensor<T> &two) { 
+        // TODO: add assertions
         Tensor<T>* temp = new Tensor<T>(&two);
-        this->frontOp = new MultiplyOperation<T>(this, temp);
-        temp->frontOp = this->frontOp;
-        return this->frontOp->forward();
+        return (*this)*(*temp);
     }
 
     Tensor<T> operator + (Tensor<T> &two) { 
+        // TODO: add assertions
         this->frontOp = new AddOperation<T>(this, &two);
         two.frontOp = this->frontOp;
         return this->frontOp->forward();
     }
 
     Tensor<T> operator + (const Tensor<T> &two) { 
+        // TODO: add assertions
         Tensor<T>* temp = new Tensor<T>(&two);
-        this->frontOp = new AddOperation<T>(this, temp);
-        temp->frontOp = this->frontOp;
-        return this->frontOp->forward();
+        return (*this)+(*temp);
     }
 
     Tensor<T> operator / (Tensor<T> &two) { 
+        // TODO: add assertions
         this->frontOp = new DivideOperation<T>(this, &two);
         two.frontOp = this->frontOp;
         return this->frontOp->forward();
     }
 
     Tensor<T> operator / (const Tensor<T> &two) { 
+        // TODO: add assertions
         Tensor<T>* temp = new Tensor<T>(&two);
-        this->frontOp = new DivideOperation<T>(this, temp);
-        temp->frontOp = this->frontOp;
+        return (*this)/(*temp);
+    }
+
+    // Dot Product
+    Tensor<T> dot(Tensor<T> &two) { 
+        // TODO: add assertions
+        this->frontOp = new DotOperation<T>(this, &two);
+        two.frontOp = this->frontOp;
         return this->frontOp->forward();
     }
 
     Tensor<T> exp() { 
+        // TODO: add assertions
         this->frontOp = new ExponentOperation<T>(this);
         return this->frontOp->forward();
     }
+
 };
 
 #endif

--- a/tensor.h
+++ b/tensor.h
@@ -122,3 +122,4 @@ class Tensor {
 };
 
 #endif
+

--- a/test.cpp
+++ b/test.cpp
@@ -1,0 +1,190 @@
+#include<iostream>
+#include <gtest/gtest.h>
+#include "matrix.h"
+
+using namespace std;
+
+
+TEST( MATRIX_TESTS, MatrixCreationShapeValidation) {
+    // Checks shape validation of Matrix
+    ASSERT_DEATH({
+        vector<int> a({1,2,3,4,5,6});
+        vector<int> shape1({2,4});
+        Matrix<int> m1(a,shape1);
+    }, "Shape and size of vector are incompatible !");
+
+    // testing for no asserts with various dimensions that can used in nd matrix
+    vector<int> a({1,2,3,4,5,6});
+    vector<int> shape1({2,3});
+    vector<int> shape2({1,1,1,2,3});
+    vector<int> shape3({2,3,1,1,1});
+    Matrix<int> m1(a,shape1);
+    m1 = Matrix<int>(a,shape2);
+    m1 = Matrix<int>(a,shape3);
+}
+
+TEST( MATRIX_TESTS, MatrixOperationShapeValidation) {
+    // Checks for matrix addition
+    ASSERT_DEATH({
+        vector<int> a({1,2,3,4,5,6});
+        vector<int> shape1({2,3});
+        vector<int> b({1,2,3,4,5,6});
+        vector<int> shape2({3,2});
+        Matrix<int> m1(a,shape1);
+        Matrix<int> m2(b,shape2);
+        auto ans = m1+m2;
+    }, "Shapes aren't compatible for addition !");
+
+    // multiplication
+    // Checks for matrix addition
+    ASSERT_DEATH({
+        vector<int> a({1,2,3,4,5,6});
+        vector<int> shape1({2,3});
+        vector<int> b({1,2,3,4,5,6});
+        vector<int> shape2({3,2});
+        Matrix<int> m1(a,shape1);
+        Matrix<int> m2(b,shape2);
+        auto ans = m1*m2;
+    }, "Shapes aren't compatible for multiplication !");
+
+    // division
+    // Checks for matrix addition
+    ASSERT_DEATH({
+        vector<int> a({1,2,3,4,5,6});
+        vector<int> shape1({2,3});
+        vector<int> b({1,2,3,4,5,6});
+        vector<int> shape2({3,2});
+        Matrix<int> m1(a,shape1);
+        Matrix<int> m2(b,shape2);
+        auto ans = m1/m2;
+    }, "Shapes aren't compatible for division !");
+
+    // dot product shape checks
+    ASSERT_DEATH({
+        vector<int> a({1,2,3,4,5,6});
+        vector<int> shape1({2,3});
+        vector<int> b({1,2,3,4,5,6});
+        vector<int> shape2({2,3});
+        Matrix<int> m1(a,shape1);
+        Matrix<int> m2(b,shape2);
+        auto ans = m1.dot(m2);
+    }, "Shapes aren't compatible for dot product !");
+
+    ASSERT_DEATH({
+        vector<int> a({1,2,3,4,5,6});
+        vector<int> shape1({2,3});
+        vector<int> b({1,2,3,4,5,6});
+        vector<int> shape2({3,2,1});
+        Matrix<int> m1(a,shape1);
+        Matrix<int> m2(b,shape2);
+        auto ans = m1.dot(m2);
+    }, "Shapes aren't compatible for dot product !");
+}
+
+template<typename T>
+bool isMatrixEqual(Matrix<T> &lhs, Matrix<T> &rhs) {
+    int n = lhs.shape.size();
+    int m = rhs.shape.size();
+
+    if(n != m) {
+        return false;
+    }
+
+    for(int i = 0; i<n;i++) {
+        if(lhs.shape[i] != rhs.shape[i]) {
+            return false;
+        }
+    }
+
+    n = lhs.val.size();
+
+    for(int i = 0;i<n;i++) {
+        if(lhs.val[i] != rhs.val[i]) {
+            return false;
+        }
+    }
+
+
+
+    return true;
+}
+
+TEST( MATRIX_TESTS, MatrixOperationAdditionCheck) {
+    
+    vector<int> a({1,2,3});
+    vector<int> shape1({1,3});
+    vector<int> b({1,2,3});
+    vector<int> shape2({1,3});
+    Matrix<int> m1(a,shape1);
+    Matrix<int> m2(b,shape2);
+    auto ans = m1+m2;
+    Matrix<int> res({2,4,6},{1,3});
+
+    ASSERT_TRUE(isMatrixEqual<int>(ans,res));
+
+}
+
+TEST( MATRIX_TESTS, MatrixOperationMultiplicationCheck) {
+
+    vector<int> a({1,2,3});
+    vector<int> shape1({1,3});
+    vector<int> b({1,2,3});
+    vector<int> shape2({1,3});
+    Matrix<int> m1(a,shape1);
+    Matrix<int> m2(b,shape2);
+    auto ans = m1*m2;
+    Matrix<int> res({1,4,9},{1,3});
+
+    ASSERT_TRUE(isMatrixEqual<int>(ans,res));
+}
+
+TEST( MATRIX_TESTS, MatrixOperationDivisionCheck) {
+    vector<int> a({9,4,3});
+    vector<int> shape1({1,3});
+    vector<int> b({1,2,3});
+    vector<int> shape2({1,3});
+    Matrix<int> m1(a,shape1);
+    Matrix<int> m2(b,shape2);
+    auto ans = m1/m2;
+    Matrix<int> res({9,2,1},{1,3});
+
+    ASSERT_TRUE(isMatrixEqual<int>(ans,res));
+}
+
+TEST( MATRIX_TESTS, MatrixOperationPowerCheck) {
+    vector<int> a({1,2,3});
+    vector<int> shape1({1,3});
+    Matrix<int> m1(a,shape1);
+    auto ans = m1^2;
+    Matrix<int> res({1,4,9},{1,3});
+    ASSERT_TRUE(isMatrixEqual<int>(ans,res));
+}
+
+TEST( MATRIX_TESTS, MatrixOperationExponentCheck) {
+    vector<float> a({1,2,3});
+    vector<int> shape1({1,3});
+    Matrix<float> m1(a,shape1);
+    auto ans = m1.exp();
+    Matrix<float> res({ (float)exp(1),  (float)exp(2),  (float)exp(3)},{1,3});
+
+    ASSERT_TRUE(isMatrixEqual<float>(ans,res));
+}
+
+TEST( MATRIX_TESTS, MatrixOperationDotProductCheck) {
+    vector<int> a({1,2,3,1,2,3});
+    vector<int> shape1({2,1,3});
+    vector<int> b({1,2,3});
+    vector<int> shape2({3,1});
+    Matrix<int> m1(a,shape1);
+    Matrix<int> m2(b,shape2);
+    auto ans = m1.dot(m2);
+    Matrix<int> res({14,14},{2,1,1});
+
+    ASSERT_TRUE(isMatrixEqual(ans,res));
+}
+
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/test.cpp
+++ b/test.cpp
@@ -188,3 +188,4 @@ int main(int argc, char **argv) {
 
     return RUN_ALL_TESTS();
 }
+

--- a/tfclone.h
+++ b/tfclone.h
@@ -1,0 +1,2 @@
+#include "tensor.h" 
+#include "operations_Impl.h"

--- a/tfclone.h
+++ b/tfclone.h
@@ -1,2 +1,3 @@
 #include "tensor.h" 
 #include "operations_Impl.h"
+


### PR DESCRIPTION
Now Tensor's support arrays of various shapes to be initialised. Also dot product multiplication between tensors is supported. The backward pass is left to be done and so are the tests.
Lots of changes to the overall structure of ops and tensors. Hence this is a big change. I'll put the Backward op and test in other pull requests.